### PR TITLE
Fix aggregated status retrieval

### DIFF
--- a/1. Notebooks/dataset_utils.py
+++ b/1. Notebooks/dataset_utils.py
@@ -164,7 +164,7 @@ def build_dataset(
         start_date,
         end_date,
         interval_minutes=interval_minutes,
-        include_status=include_status_raw and not aggregate,
+        include_status=include_status_raw,
         search_method=search_method,
         engine=engine,
     )


### PR DESCRIPTION
## Summary
- fix dataset_utils status retrieval when aggregating datasets

## Testing
- `python -m py_compile '1. Notebooks/dataset_utils.py'`
- `find "1. Notebooks" -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_683f63111878832d94efa64c3aac8a44