### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/1. Notebooks/AGENTS.md
+++ b/1. Notebooks/AGENTS.md
@@ -1,0 +1,19 @@
+## Build
+```bash
+echo "No build step required"
+```
+
+## Test
+```bash
+python -m py_compile *.py
+```
+
+## Lint
+```bash
+echo "No lint step defined"
+```
+
+## Deploy
+```bash
+echo "Launch notebooks with Voila or Jupyter as needed"
+```

--- a/2. Stored Procedures/AGENTS.md
+++ b/2. Stored Procedures/AGENTS.md
@@ -1,0 +1,19 @@
+## Build
+```bash
+echo "No build step required for SQL procedures"
+```
+
+## Test
+```bash
+echo "No tests defined"
+```
+
+## Lint
+```bash
+echo "No lint step defined"
+```
+
+## Deploy
+```bash
+echo "Deploy procedures using your SQL Server tools"
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# EnergieApp Repository Guide
+
+This project contains two main source folders:
+
+- **1. Notebooks** – Jupyter notebooks and helper Python modules.
+- **2. Stored Procedures** – SQL Server procedures used by the notebooks.
+
+Each directory has its own `AGENTS.md` with build and deployment commands:
+
+- [1. Notebooks/AGENTS.md](1. Notebooks/AGENTS.md)
+- [2. Stored Procedures/AGENTS.md](2. Stored Procedures/AGENTS.md)
+
+The notebooks expect a Conda environment defined in `1. Notebooks/environment.yml`.
+Deployment typically involves launching the notebooks with Voila and loading the SQL
+procedures into your database.


### PR DESCRIPTION
## Summary
- add AGENTS guides for notebooks and stored procedures
- document overall repository structure in root AGENTS

## Testing
- `python -m py_compile *.py` in `1. Notebooks`


------
https://chatgpt.com/codex/tasks/task_e_6843515937dc832c9da0d2aebc2c10f3